### PR TITLE
fix: Use newer version for install, to fix keycloak fetch issue

### DIFF
--- a/kheopsinstall.sh
+++ b/kheopsinstall.sh
@@ -14,7 +14,7 @@ then
   exit 1
 fi
 
-download_branch="insecure-install-v1.1.1"
+download_branch="insecure-install-v1.1.2"
 downloadURI="https://raw.githubusercontent.com/OsiriX-Foundation/KheopsOrchestration/$download_branch"
 
 secretpath="kheops/secrets"


### PR DESCRIPTION
Just updating the download branch to 1.1.2 so that the keycloak quay.io location can be pulled in correctly so that things install again without changes.